### PR TITLE
Fix missing import in pankegg_app

### DIFF
--- a/pankegg_app.py
+++ b/pankegg_app.py
@@ -9,6 +9,7 @@ import json
 import click
 import sys
 import importlib
+import importlib.resources
 from importlib.resources import files
 import pandas as pd
 import numpy as np


### PR DESCRIPTION
## Summary
- fix missing importlib.resources module reference

## Testing
- `python -m py_compile pankegg_app.py`
- `python -m py_compile pankegg_make_db.py`


------
https://chatgpt.com/codex/tasks/task_e_683ff231bd54832d9208ab7eb5b59f86