### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Start the web server using the database present in the repository:
 python pankegg_app.py --d data/pankegg.db
 ```
 
-or use the the database you generated in point 3:
+or use the database you generated in point 3:
 
 ```bash
 python pankegg_app.py --d pankegg_test_data/test_sourmash


### PR DESCRIPTION
## Summary
- fix duplicate word in README

## Testing
- `python pankegg_make_db.py -h`
- `python pankegg_app.py --help`


------
https://chatgpt.com/codex/tasks/task_e_683ff3e2f7a0832d9b8b40457450f837